### PR TITLE
Support results without interval time period metadata

### DIFF
--- a/src/process.jl
+++ b/src/process.jl
@@ -12,7 +12,8 @@ function process(
         addconfigs!(h5file, systemdata)
         membership_idxs = addcollections!(h5file, systemdata, strlen, compressionlevel)
         addtimes!(h5file, systemdata, timestampformat, compressionlevel)
-        addblocks!(h5file, systemdata, timestampformat, compressionlevel)
+        length(systemdata.intervals) > 0 &&
+            addblocks!(h5file, systemdata, timestampformat, compressionlevel)
         addvalues!(h5file, systemdata, membership_idxs, resultvalues,
                    compressionlevel, targetsample)
     end
@@ -217,7 +218,6 @@ function addtimes!(f::HDF5.File, data::PLEXOSSolutionDataset,
     end
 
 end
-
 
 function addblocks!(f::HDF5.File, data::PLEXOSSolutionDataset,
                     localformat::DateFormat, compressionlevel::Int)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,6 +1,7 @@
 using H5PLEXOS
 
 zipfiles = ["Model Base_8200 Solution.zip",
+            "Model Base_8200 NoInterval Solution.zip",
             "Model DAY_AHEAD_NO_TX Solution.zip",
             "Model DAY_AHEAD_NO_TX Stochastic Solution.zip",
             "Model DAY_AHEAD_ALL_TX Solution.zip",


### PR DESCRIPTION
Don't define interval-block mappings in `/metadata/blocks` if interval metadata is missing