### PR TITLE
Add troubleshooting for InfoZIP.

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,22 @@ Once this is done the package can be installed normally.
 pkg> add H5PLEXOS
 ```
 
+While running this command, you may run into issues with the `InfoZIP` package.
+To solve, open the following file:
+"~/.julia/packages/InfoZIP/{unique-hash-code}/Project.toml"
+and delete the `[compat]` section.
+
+Then, run
+```julia
+pkg> add InfoZIP
+pkg> build HDF5
+```
+
+Now you should be able to use `h5plexos`. Test with
+```julia
+julia> using H5PLEXOS
+```
+
 ## Processing solutions
 
 The module exports the  function `process` which handles conversion. For


### PR DESCRIPTION
These steps worked for me, not sure if there is a different workaround for InfoZIP.

Here is the error I was seeing:

```julia
(@v1.9) pkg> add InfoZIP
   Resolving package versions...
ERROR: Compat `Julia` not listed in `deps`, `weakdeps` or `extras` section at "/Users/mschwarz/.julia/packages/InfoZIP/3AT7m/Project.toml".
```